### PR TITLE
MC Memory Discussion

### DIFF
--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -927,6 +927,33 @@ values. It can also trace rays at any time via a method in which the ray length
 is repeatedly clipped using signed distance values to approach a surface in a
 process called ray marching \cite{Tomczak_2012}.
 
+\section{Memory Considerations}
+
+\subsection{Monte Carlo Sources}
+  
+Monte Carlo memory consumption is normally attributed to cross-section data and
+tally data structures. Cross-section data is necessary to represent the physicsl
+processes governing particle transport through the virtual geometry. Various
+formats of this data exist with both continuous and discrete representation of
+cross section information. Continuous representations of data are compact in
+terms of memory requirements, but are more computationally expensive to evaluate
+when sampling these probability distribution functions. Discrete representations
+of this data consume more memory in simulation, but require less computation
+when extracting data. The amount of memory consumed for nuclear data is
+dependent on the number of unique materials used in the problem and material
+composition as well. This data can occupy the majority of simulation memory for
+large problems with many materials.
+
+\subsection{Parallel Computation Schemes}
+
+For the Monte Carlo code used in this work, MCNP, is a parallelism method
+applied is a master/slave scheme standard for many Message Passing Interface
+(MPI) applications. The master process is responsible for initializing the
+problem, determining the load balance for the number of parallel processess
+requested by the user, and collecting/accumulating information at the end of the
+simulation.
+
+\subsection{Geometric Representation}
 
 \section{Summary}
 

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -1004,6 +1004,7 @@ data structures are kept to a minimum if possible.
     ATR   & 294          & 675 & 865  \\
     UWNR  & 213          & 435 & 1250 \\
     nTOF  & 56           & 88  & 416  \\
+    ITER  & 2592  & 5947 &  6679\\
     \hline
   \end{tabular}
   \caption[Memory summary of performance benchmark models.]{A summary of the
@@ -1023,6 +1024,25 @@ even more pronounced in larger production models seen in Chapters
 \ref{ch:simd_bvh} and \ref{ch:high_valence}, though shared memory
 implementations for higher per-node memory efficiency are on DAGMC's development
 path.
+
+In addition to the benchmark models from Table \ref{dag-mcnp-benchmarks}, Table
+\ref{tab:dag-mcnp-benchmarks-mem} includes a model of the International
+Thermonuclear Experimental Reactor (ITER). ITER is a demonstration nuclear
+fusion device currently under construction in southern France. An analysis of
+DAGMC was performed at the University of Wisconsin - Madison to calculate a
+spatial mapping of the dose rate induced by irradiated components of the machine
+for various cooling times or times after shutdown of the device.  This shutdown
+dose rate calculation was broken into seven spatial source meshes to avoid
+exceeding the memory limits of the HPC cluster used for this analysis. The
+values displayed in the table represent the memory usage for one of the seven
+simulations required to complete the analysis. This model was included as a
+current representation of the analysis work being performed in DAGMC. It was not
+included in the comparative benchmark analysis of DAGMC because no native MCNP
+counterpart of this model exists. This model contains components created in CAD
+with no analogous MCNP representation, another reason CAD-based tessellations
+are desirable for MCRT. The simulation memory footprint of the ITER model is
+much larger in simulation, so much so that the number of processes allocated to
+a node was memory-limited rather than core-limited during analysis.
 
 \section{Summary}
 

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -927,12 +927,15 @@ values. It can also trace rays at any time via a method in which the ray length
 is repeatedly clipped using signed distance values to approach a surface in a
 process called ray marching \cite{Tomczak_2012}.
 
-\section{Memory Considerations}
+\section{Monte Carlo Memory Considerations}
 
-\subsection{Monte Carlo Sources}
-  
-Monte Carlo memory consumption is normally attributed to cross-section data and
-tally data structures. Cross-section data is necessary to represent the physicsl
+The bulk of Monte Carlo memory consumption in native calculations is attributed
+to nuclear cross-section data and tally data structures with the analytic CSG
+geometry representation taking up a small portion of the overall program memory.
+
+\subsection{Cross-Section Data}
+
+Cross-section data is necessary to represent the physicsl
 processes governing particle transport through the virtual geometry. Various
 formats of this data exist with both continuous and discrete representation of
 cross section information. Continuous representations of data are compact in
@@ -944,22 +947,87 @@ dependent on the number of unique materials used in the problem and material
 composition as well. This data can occupy the majority of simulation memory for
 large problems with many materials.
 
+\subsection{Tally Data Structures}
+
+Results of the Monte Carlo calculation are kept as tallies of particle
+contributions to physical quantities at various locations in the physical
+model. Tallies on surfaces or in cells change the memory usage of the simulation
+insignificantly, unless additional data is needed to calculate derived
+quantities. Mesh-based tallies on the other hand can dominate the memory
+usage. In MCNP and many other Monte Carlo codes, mesh tallies are defined by the
+user as structured grids in either Cartesian, cylindrical, or spherical
+coordinates. These tallies are often used for better spatial resoluion of
+physical data in the simulation and for coupling to analysis in other
+engineering domains. Tetrahedral mesh tallies are also supported by several
+Monte Carlo codes DAGMC interacts with, including MCNP
+\cite{LANL_MCNP5_VOLIII}. The size of these tallies vary based on the needs of
+the user and the tradeoffs associated with spatial resolution of solutions and
+statistical convergence related to mesh element sizes.
+
 \subsection{Parallel Computation Schemes}
 
-For the Monte Carlo code used in this work, MCNP, is a parallelism method
-applied is a master/slave scheme standard for many Message Passing Interface
-(MPI) applications. The master process is responsible for initializing the
-problem, determining the load balance for the number of parallel processess
-requested by the user, and collecting/accumulating information at the end of the
-simulation.
+For the Monte Carlo code used in this work, MCNP, the parallelism method applied
+is a master/slave scheme standard for many applications using the Message
+Passing Interface (MPI) \cite{Forum_1994}. The master process is responsible for
+initializing the problem, determining the load balance for the number of
+parallel processess requested by the user, and collecting/accumulating
+information at the end of the simulation. In MCNP, particle histories are
+divided into equal segments among the slave processes for evaluation. More
+information on the method for particle history division and random number
+sequence assignment was detailed by Deng and Xie \cite{Deng_1999}. For each
+slave process, a corresponding set of the nuclear data, tally data structures,
+and geometry representation are created. Duplication of the geometry
+representation has a significant implications for the use of CAD-based
+tessellations.
 
-\subsection{Geometric Representation}
+\subsection{Impact on CAD-Base Geometry}
+
+The tesselations resulting from CAD geometries consume much more memory than
+corresponding CSG representations. This must be taken into consideration when
+planning parallel simulations clusters where the limitation for the number of
+processes per CPU can be limited by the memory used in a single process. Because
+DAGMC's CAD-based particle tracking is an addition to MCNP, it has no influence
+on the parallelism data model. Given that geometry representations are required
+to exist in each process of the parallel simluation, memory usage in DAGMC is
+closely monitored. Some of this memory usage is largely uncontrollable due to
+the reliance on CUBIT or Trelis and their's underlying tessellation algorithms,
+but additional data used to maintain geometric relationships and build acceleration data
+structures are kept to a minimum if possible.
+
+\begin{table}[H]
+    \centering
+  \begin{tabular}{l c c c}
+    \toprule
+    Model & Tessellation (MB) & MOAB BVH (MB) \\
+    \hline
+    FNG   & 92           & 168 \\
+    ATR   & 294          & 675 \\
+    UWNR  & 213          & 435 \\
+    nTOF  & 56           & 88  \\
+    \hline
+  \end{tabular}
+  \caption[Memory summary of performance benchmark models.]{A summary of the
+    memory usage for the performance benchmark models shown in Table
+    \ref{dag-mcnp-benchmarks} both with and without accelleration data structures.}
+  \label{tab:dag-mcnp-benchmarks-mem}
+\end{table}
+
+Table \ref{tab:dag-mcnp-benchmarks-mem} shows the memory usage for all of the
+benchmark models used to assess DAG-MCNP's performance relative to native MCNP
+geometry representations in Section \ref{sec:problem-statement}. All of the
+models consume relatively low amounts of memory compared to the storage found on
+many CPUs in High Performance Computing (HPC) environments, but the addition of
+accelleration data structures, in this instance MOAB's BVH of OBBs, can more
+than double the memory occupied for the geometry representation. This effect
+becomes even more pronounced in larger production models seen in Chapters
+\ref{ch:simd_bvh} and \ref{ch:high_valence}.
 
 \section{Summary}
 
 This discussion of the CAD-based MCRT-t via the DAGMC toolkit, hierarchical
-spatial data structures, and SDF generation in this chapter provides a basis for
-the work performed in the remainder of this document. Chapter
+spatial data structures, SDF generation, and context for memory use in parallel
+simulations with MCNP in this chapter provides a basis for the work performed in
+the remainder of this document. Chapter
 \ref{ch:preconditioning} discusses the implementation and application of SDFs in
 DAGMC's framework. Next, Chapter \ref{ch:simd_bvh} presents work on BVHs
 optimized for use in DAGMC and extensions of those methods to provide robust

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -927,7 +927,7 @@ values. It can also trace rays at any time via a method in which the ray length
 is repeatedly clipped using signed distance values to approach a surface in a
 process called ray marching \cite{Tomczak_2012}.
 
-\section{Monte Carlo Memory Considerations}
+\section{Monte Carlo Memory Considerations}\label{sec:mc_mem}
 
 The bulk of Monte Carlo memory consumption in native calculations is attributed
 to nuclear cross-section data and tally data structures with the analytic CSG

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -1026,23 +1026,23 @@ implementations for higher per-node memory efficiency are on DAGMC's development
 path.
 
 In addition to the benchmark models from Table \ref{dag-mcnp-benchmarks}, Table
-\ref{tab:dag-mcnp-benchmarks-mem} includes a model of the International
-Thermonuclear Experimental Reactor (ITER). ITER is a demonstration nuclear
-fusion device currently under construction in southern France. An analysis of
-DAGMC was performed at the University of Wisconsin - Madison to calculate a
-spatial mapping of the dose rate induced by irradiated components of the machine
-for various cooling times or times after shutdown of the device.  This shutdown
-dose rate calculation was broken into seven spatial source meshes to avoid
-exceeding the memory limits of the HPC cluster used for this analysis. The
-values displayed in the table represent the memory usage for one of the seven
-simulations required to complete the analysis. This model was included as a
-current representation of the analysis work being performed in DAGMC. It was not
-included in the comparative benchmark analysis of DAGMC because no native MCNP
-counterpart of this model exists. This model contains components created in CAD
-with no analogous MCNP representation, another reason CAD-based tessellations
-are desirable for MCRT. The simulation memory footprint of the ITER model is
-much larger in simulation, so much so that the number of processes allocated to
-a node was memory-limited rather than core-limited during analysis.
+\ref{tab:dag-mcnp-benchmarks-mem} includes a model of a demonstration nuclear
+fusion device currently under construction in southern France.  An analysis of
+ITER using DAGMC was performed at the University of Wisconsin - Madison to
+calculate a spatial mapping of the dose rate induced by irradiated components of
+the machine for various cooling times or times after shutdown of the device.
+This shutdown dose rate calculation was broken into seven spatial source meshes
+to avoid exceeding the memory limits of the HPC cluster used for this
+analysis. The values displayed in the table represent the memory usage for one
+of the seven simulations required to complete the analysis. This model was
+included as a current representation of the analysis work being performed in
+DAGMC. It was not included in the comparative benchmark analysis of DAGMC
+because no native MCNP counterpart of this model exists. This model contains
+components created in CAD with no analogous MCNP representation, another reason
+CAD-based tessellations are desirable for MCRT. The simulation memory footprint
+of the ITER model is much larger in simulation, so much so that the number of
+processes allocated to a node was memory-limited rather than core-limited during
+analysis.
 
 \section{Summary}
 

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -938,14 +938,16 @@ geometry representation taking up a small portion of the overall program memory.
 Cross-section data is necessary to represent the physical
 processes governing particle transport through the virtual geometry. Various
 formats of this data exist with both continuous and discrete representation of
-cross section information. Continuous representations of data are compact in
-terms of memory requirements, but are more computationally expensive to evaluate
-when sampling these probability distribution functions. Discrete representations
-of this data consume more memory in simulation, but require less computation
-when extracting data. The amount of memory consumed for nuclear data is
-dependent on the number of unique materials used in the problem and material
-composition as well. This data can occupy the majority of simulation memory for
-large problems with many materials.
+cross section information.
+
+Continuous representations of this data can occupy a considerable amount of
+space and are more computationally expensive to evaluate than discrete
+representations, but are also more accurate. Discrete representations of this
+data consume more memory in simulation, but require less computation when
+extracting data. The amount of memory occupied by nuclear data is dependent on
+the number of unique materials used in the problem as well as the material
+composition in terms of the unique isotopes in the problem. This data can occupy
+the majority of simulation memory for large problems with many materials.
 
 \subsection{Tally Data Structures}
 
@@ -964,7 +966,7 @@ Monte Carlo codes DAGMC interacts with, including MCNP
 the user and the trade-offs associated with spatial resolution of solutions and
 statistical convergence related to mesh element sizes.
 
-\subsection{Parallel Computation Schemes}
+\subsection{Impact on CAD-Based Tessellations}
 
 For the Monte Carlo code used in this work, MCNP, the parallelism method applied
 is a master/slave scheme standard for many applications using the Message
@@ -980,30 +982,28 @@ and geometry representation are created. Duplication of the geometry
 representation has a significant implications for the use of CAD-based
 tessellations.
 
-\subsection{Impact on CAD-Base Geometry}
-
 The tessellations resulting from CAD geometries consume much more memory than
 corresponding CSG representations. This must be taken into consideration when
-planning parallel simulations clusters where the limitation for the number of
-processes per CPU can be limited by the memory used in a single process. Because
-DAGMC's CAD-based particle tracking is an addition to MCNP, it has no influence
-on the parallelism data model. Given that geometry representations are required
-to exist in each process of the parallel simulation, memory usage in DAGMC is
+planning parallel simulations on clusters where the limitation for the number of
+processes per CPU is often the memory used per process. Because DAGMC's
+CAD-based particle tracking is an addition to MCNP, it has no influence on the
+parallelism data model. Given that geometry representations are required to
+exist in each process of the parallel simulation, memory usage in DAGMC is
 closely monitored. Some of this memory usage is largely uncontrollable due to
-the reliance on CUBIT or Trelis' underlying tessellation algorithms,
-but additional data used to maintain geometric relationships and build acceleration data
-structures are kept to a minimum if possible.
+the reliance on CUBIT or Trelis' underlying tessellation algorithms, but
+additional data used to maintain geometric relationships and build acceleration
+data structures are kept to a minimum if possible.
 
 \begin{table}[H]
     \centering
   \begin{tabular}{l c c c}
     \toprule
-    Model & Tessellation (MB) & Tessellation and MOAB BVH (MB) \\
+    Model & Tessellation (MB) & Tessellation and MOAB BVH (MB) & Simulation (MB) \\
     \hline
-    FNG   & 92           & 168 \\
-    ATR   & 294          & 675 \\
-    UWNR  & 213          & 435 \\
-    nTOF  & 56           & 88  \\
+    FNG   & 92           & 168 & 262  \\
+    ATR   & 294          & 675 & 865  \\
+    UWNR  & 213          & 435 & 1250 \\
+    nTOF  & 56           & 88  & 416  \\
     \hline
   \end{tabular}
   \caption[Memory summary of performance benchmark models.]{A summary of the
@@ -1017,10 +1017,12 @@ benchmark models used to assess DAG-MCNP's performance relative to native MCNP
 geometry representations in Section \ref{sec:problem-statement}. All of the
 models consume relatively low amounts of memory compared to the storage found on
 many CPUs in High Performance Computing (HPC) environments, but the addition of
-acceleration data structures, in this instance MOAB's BVH of OBBs, can more
-than double the memory occupied for the geometry representation. This effect
-becomes even more pronounced in larger production models seen in Chapters
-\ref{ch:simd_bvh} and \ref{ch:high_valence}.
+acceleration data structures, in this instance MOAB's BVH of OBBs, can more than
+double the memory occupied for the geometry representation. This effect becomes
+even more pronounced in larger production models seen in Chapters
+\ref{ch:simd_bvh} and \ref{ch:high_valence}, though shared memory
+implementations for higher per-node memory efficiency are on DAGMC's development
+path.
 
 \section{Summary}
 

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -935,7 +935,7 @@ geometry representation taking up a small portion of the overall program memory.
 
 \subsection{Cross-Section Data}
 
-Cross-section data is necessary to represent the physicsl
+Cross-section data is necessary to represent the physical
 processes governing particle transport through the virtual geometry. Various
 formats of this data exist with both continuous and discrete representation of
 cross section information. Continuous representations of data are compact in
@@ -956,12 +956,12 @@ insignificantly, unless additional data is needed to calculate derived
 quantities. Mesh-based tallies on the other hand can dominate the memory
 usage. In MCNP and many other Monte Carlo codes, mesh tallies are defined by the
 user as structured grids in either Cartesian, cylindrical, or spherical
-coordinates. These tallies are often used for better spatial resoluion of
+coordinates. These tallies are often used for better spatial resolution of
 physical data in the simulation and for coupling to analysis in other
 engineering domains. Tetrahedral mesh tallies are also supported by several
 Monte Carlo codes DAGMC interacts with, including MCNP
 \cite{LANL_MCNP5_VOLIII}. The size of these tallies vary based on the needs of
-the user and the tradeoffs associated with spatial resolution of solutions and
+the user and the trade-offs associated with spatial resolution of solutions and
 statistical convergence related to mesh element sizes.
 
 \subsection{Parallel Computation Schemes}
@@ -970,7 +970,7 @@ For the Monte Carlo code used in this work, MCNP, the parallelism method applied
 is a master/slave scheme standard for many applications using the Message
 Passing Interface (MPI) \cite{Forum_1994}. The master process is responsible for
 initializing the problem, determining the load balance for the number of
-parallel processess requested by the user, and collecting/accumulating
+parallel processes requested by the user, and collecting/accumulating
 information at the end of the simulation. In MCNP, particle histories are
 divided into equal segments among the slave processes for evaluation. More
 information on the method for particle history division and random number
@@ -982,15 +982,15 @@ tessellations.
 
 \subsection{Impact on CAD-Base Geometry}
 
-The tesselations resulting from CAD geometries consume much more memory than
+The tessellations resulting from CAD geometries consume much more memory than
 corresponding CSG representations. This must be taken into consideration when
 planning parallel simulations clusters where the limitation for the number of
 processes per CPU can be limited by the memory used in a single process. Because
 DAGMC's CAD-based particle tracking is an addition to MCNP, it has no influence
 on the parallelism data model. Given that geometry representations are required
-to exist in each process of the parallel simluation, memory usage in DAGMC is
+to exist in each process of the parallel simulation, memory usage in DAGMC is
 closely monitored. Some of this memory usage is largely uncontrollable due to
-the reliance on CUBIT or Trelis and their's underlying tessellation algorithms,
+the reliance on CUBIT or Trelis' underlying tessellation algorithms,
 but additional data used to maintain geometric relationships and build acceleration data
 structures are kept to a minimum if possible.
 
@@ -1008,7 +1008,7 @@ structures are kept to a minimum if possible.
   \end{tabular}
   \caption[Memory summary of performance benchmark models.]{A summary of the
     memory usage for the performance benchmark models shown in Table
-    \ref{dag-mcnp-benchmarks} both with and without accelleration data structures.}
+    \ref{dag-mcnp-benchmarks} both with and without acceleration data structures.}
   \label{tab:dag-mcnp-benchmarks-mem}
 \end{table}
 
@@ -1017,7 +1017,7 @@ benchmark models used to assess DAG-MCNP's performance relative to native MCNP
 geometry representations in Section \ref{sec:problem-statement}. All of the
 models consume relatively low amounts of memory compared to the storage found on
 many CPUs in High Performance Computing (HPC) environments, but the addition of
-accelleration data structures, in this instance MOAB's BVH of OBBs, can more
+acceleration data structures, in this instance MOAB's BVH of OBBs, can more
 than double the memory occupied for the geometry representation. This effect
 becomes even more pronounced in larger production models seen in Chapters
 \ref{ch:simd_bvh} and \ref{ch:high_valence}.

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -998,7 +998,7 @@ structures are kept to a minimum if possible.
     \centering
   \begin{tabular}{l c c c}
     \toprule
-    Model & Tessellation (MB) & MOAB BVH (MB) \\
+    Model & Tessellation (MB) & Tessellation and MOAB BVH (MB) \\
     \hline
     FNG   & 92           & 168 \\
     ATR   & 294          & 675 \\

--- a/document/chapters/03-sdf_preconditioner.tex
+++ b/document/chapters/03-sdf_preconditioner.tex
@@ -1027,12 +1027,10 @@ physics subroutines.
 
 The SDF preconditioning method was applied in the following models:
 
-\sdfModel{ITER}{ The International Thermonuclear Experimental Reactor (ITER) is
-  a demonstration nuclear fusion device currently under construction in southern
-  France. An analysis of DAGMC was performed at the University of Wisconsin -
-  Madison to determine the nuclear heating to shield materials used as primary
-  shielding for fusion neutrons.
-}
+\sdfModel{ITER}{ITER is a demonstration nuclear fusion device currently under
+  construction in southern France. An analysis of DAGMC was performed at the
+  University of Wisconsin - Madison to determine the nuclear heating to shield
+  materials used as primary shielding for fusion neutrons. }
 
 %% \sdfModel{FNG} {
 %%   The Frascati Neutron Generator (FNG) is a neutrom source device which uses a

--- a/document/chapters/05-high_valence.tex
+++ b/document/chapters/05-high_valence.tex
@@ -688,3 +688,19 @@ impact was found for some models while a significant reduction was seen in
 others. It was also was found that these run times are significantly reduced
 despite the fact that a very small number of rays are intersected with triangles
 in HV regions as shown in Table \ref{tab:bvhrefine_production_results}.
+
+\section{Future Work}
+
+For the models studied in this chapter, any HV detection parameter below 1.0 was
+shown to be effective in reducing simulation run times. This parameter could be
+studied and optimized using a broad range of test cases to determine the best
+value for use in the general case.
+
+Alternative methods to reducing the HV performance pathology could be explored
+as well. Here, BVH data structures were modified to better suit the HV mesh
+feature. Conversely, the HV regions could also be modified to better suit the
+BVH. A re-meshing of the HV region to contain a more uniform tessellation would
+allow a BVH of AABBs to maintain traversal performance without modification to
+the BVH build, though this would presumably come at the cost of more triangles
+in the model. Re-meshing of HV regions was not explored in this work due to the
+concerns for the additional memory cost outlined in Section \ref{sec:mc_mem}.

--- a/document/frontmatter/frontmatter.tex
+++ b/document/frontmatter/frontmatter.tex
@@ -113,6 +113,7 @@
 \term{Meshset}{A group of mesh entities in MOAB}
 \term{MOAB}{Mesh Oriented dAtaBase}
 \term{MPBVH}{Mixed Precision Bounding Volume Hierarchy}
+\term{MPI}{Message Passing Interface}
 \term{nTOF}{Neutron Time of Flight model}
 \term{SAH}{Surface Area Heuristic}
 \term{SHINE}{Medical isotope facility}

--- a/document/frontmatter/frontmatter.tex
+++ b/document/frontmatter/frontmatter.tex
@@ -105,6 +105,7 @@
 \term{ERH}{Entity Ratio Heuristic}
 \term{FNG}{Frascatti Neutron Generator}
 \term{GUI}{Graphic User Interface}
+\term{HPC}{High Performance Computing}
 \term{HV}{High Valence}
 \term{Interior Node}{Node connected to both parent and child nodes in a tree}
 \term{Leaf Node}{Node connected to only parent nodes, located at the bottom of a tree}

--- a/document/refs.bib
+++ b/document/refs.bib
@@ -664,3 +664,26 @@ keywords = {I.3.7[Computer Graphics]: Three-Dimensional Graphics and Realism-Ray
 year = {2013},
 }
 
+@article{Deng_1999,
+issn = {0022-3131},
+abstract = {The coupled neutron and photon transport Monte Carlo code MCNP (version 3B) has been parallelized in parallel virtual machine (PVM) and message passing interface (MPI) by modifying a previous serial code. The new code has been verified by solving sample problems. The speedup increases linearly with the number of processors and the average efficiency is up to 99% for 12-processor.},
+journal = {Journal of Nuclear Science and Technology},
+pages = {626--629},
+volume = {36},
+publisher = {Taylor & Francis Group},
+number = {7},
+year = {1999},
+title = {Parallelization of MCNP Monte Carlo Neutron and Photon Transport Code in Parallel Virtual Machine and Message Passing Interface},
+author = {Deng, Li and Xie, Zhong-Sheng},
+keywords = {Computer Codes ; Parallel Virtual Machine ; Massage Passing Interface ; Parallelization ; Speedup ; Monte Carlo Method},
+month = {July},
+}
+
+@techreport{Forum_1994,
+author = {Forum, Message P},
+title = {MPI: A Message-Passing Interface Standard},
+year = {1994},
+source = {http://www.ncstrl.org:8900/ncstrl/servlet/search?formname=detail\&id=oai%3Ancstrlh%3Autk_cs%3Ancstrl.utk_cs%2F%2FUT-CS-94-230},
+publisher = {University of Tennessee},
+address = {Knoxville, TN, USA},
+} 


### PR DESCRIPTION
This PR addresses #6. It contains a discussion of the memory concerns for use of DAGMC with MCNP as well as some data on the performance benchmark models. Some aren't the best examples, but the fact that the MOAB BVH can more than double the footprint along with the geometry duplication in parallel makes enough of a statement, I think.

I could use some supporting data on the first section about nuclear data, but I'm not sure where to find it. I could load simulations and subtract the geometry+BVH memory I suppose...