### PR TITLE
Translation methods

### DIFF
--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -308,10 +308,10 @@ methods are listed below:
   ABAQUS mesh \cite{ABAQUS_2018}. It is expected that the volumes in these files
   do not occupy the same space and that each file contains a single, closed
   volume of triangles. Geometries can also be defined using both CSG and STL
-  representations in this format. The use of separate files to represent volumes
-  independently in this system makes interchanging parts in a geometry
-  straightforward, but ensuring that these parts do not have gaps or overlaps
-  can be a difficult task for users.}
+  representations in this format \cite{Talamo_2018}. The use of separate files
+  to represent volumes independently in this system makes interchanging parts in
+  a geometry straightforward, but ensuring that these parts do not have gaps or
+  overlaps can be a difficult task for users.}
 
 \codecallout{MCNP6}{MCNP6 \cite{Goorley_2016}, developed at Los Alamos National
   Laboratory, has added the native capability to perform transport on a

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -257,29 +257,30 @@ complex forms which would be impossible to accurately represent using CSG.
 
 \subsection{Translation-Based Methods}
 
-Another approach to CAD-Based MCRT is to leverage the native geometry
-capatilities of Monte Carlo codes by translating CAD geometries into CSG
-representations. In this approach, the fidelity of the geometric representation
-is limited to the geometric primitives available in the supported Monte Carlo
-code. Most codes support only first and second order surfaces, so higher-order
-surfaces of the CAD model must be approximated to accomodate the limited
-representation of the native code. As a result, many of these methods will
-simplify single volumes into smaller, less complex volumes able to be
-represented in CSG. This can be problematic when tally information related to
-CAD entities is desired - surface or volumetric fluxes for a single entity in
-the CAD model must now be mapped over several entities in the CSG
-representation. The lack of one-to-one correlation between CAD and CSG entities
-makes model manipulation difficult in that a change to the CAD model may result
-more or fewer geometric entities, making tacking of tally mapping difficult from
-CAD to CSG. Several translation approaches have been developed oriented toward
-the Monte Carlo N-Particle (MCNP) input format developed at Los Alamos National
-Laboratory \cite{LANL_MCNP5_VOLIII}. A few of these tools are described below:
+One approach to CAD-Based MCRT is to leverage the native geometry capabilities
+of Monte Carlo codes by translating CAD geometries into CSG representations. In
+this approach, the fidelity of the geometric representation is limited to the
+geometric primitives available in the supported Monte Carlo code. Most codes
+support only first and second order surfaces, so higher-order surfaces of the
+CAD model must be approximated to accommodate the limited representation of the
+native code. As a result, many of these methods will simplify single volumes
+into smaller, less complex volumes able to be represented in CSG. This can be
+problematic when tally information related to CAD entities is desired - surface
+or volumetric fluxes for a single entity in the CAD model must now be mapped to
+several entities in the CSG representation. The lack of one-to-one correlation
+between CAD and CSG entities makes model manipulation difficult in that a change
+to the CAD model may result more or fewer CSG entities after translation, adding
+difficulty to tracking tally mapping. Several translation approaches have been
+developed oriented toward the Monte Carlo N-Particle (MCNP) input format
+developed at Los Alamos National Laboratory \cite{LANL_MCNP5_VOLIII}. A few of
+these tools are described below:
 
 \codecallout{MCAM}{The Monte Carlo Automatic Modeling (MCAM) tool was developed
   at the Chinese Academy of Sciences \cite{Yu_2013}. It supports both CAD-to-CSG
-  and CSG-to-CAD conversion, relying on the ACIS \cite{ACIS_2018}. It is capable
-  of fixing gaps and overlaps in models and supports geometry creation. Volumes
-  are decomposed into simplified, convex volumes during CAD-to-CSG translation.}
+  and CSG-to-CAD conversion, relying on the ACIS \cite{ACIS_2018} geometry
+  engine. It is capable of fixing gaps and overlaps in models and supports
+  geometry creation. Volumes are decomposed into simplified, convex volumes
+  during CAD-to-CSG translation.}
 
 \codecallout{McCad}{McCad was developed at the Karlsruhe Institute of Technology
   in Germany and supports both CAD-to-CSG and CSG-to-CAD model conversion,
@@ -288,8 +289,9 @@ Laboratory \cite{LANL_MCNP5_VOLIII}. A few of these tools are described below:
   McCad. McCad also decomposes single volumes into multiple volumes with
   simplified CAD definitions.}
 
-Though other translation-based methods exist, these tools have the widest
-user base and largest development efforts behind them at the time of this work.
+Though other translation-based methods exist, these tools were selected for
+discussion based on usage in analysis and development efforts at the
+time of this work.
 
 \subsection{Direct Transport Methods}
 
@@ -297,50 +299,51 @@ In the direct approach to CAD-Based MCRT, geometric queries are performed
 directly on the CAD geometry. Unlike translation-based approaches, physics codes
 must be modified to direct geometric operations to the CAD-Based
 interfaces. Some direct methods perform queries on analytic CAD representations
-while others use discretized forms, but no simplification of the geometry is
-involved. Direct computation on CAD geometries tends to be slower than using
-native geometry because particle tracking is more computationally expensive on
-complicated surface representations. Several recent implementations of direct
-methods are listed below:
+while others use discretized forms, but in either case no simplification of the
+geometry is involved. Direct computation on CAD geometries tends to be slower
+than using native geometry because particle tracking is more computationally
+expensive on complicated surface representations. Several recent implementations
+of direct methods are listed below:
 
 \codecallout{SERPENT}{Serpent \cite{Leppanen_2015} provides CAD-based transport
-  using a geometry represented by individual stereolithography (STL) files or
-  ABAQUS mesh \cite{ABAQUS_2018}. It is expected that the volumes in these files
-  do not occupy the same space and that each file contains a single, closed
-  volume of triangles. Geometries can also be defined using both CSG and STL
-  representations in this format \cite{Talamo_2018}. The use of separate files
-  to represent volumes independently in this system makes interchanging parts in
-  a geometry straightforward, but ensuring that these parts do not have gaps or
-  overlaps can be a difficult task for users.}
+  using a geometry represented by individual stereo-lithography (STL) files or a
+  ABAQUS mesh \cite{ABAQUS_2018} generated using CUBIT \cite{Blacker_1994}. It
+  is expected that the volumes in these files do not occupy the same space and
+  that each file contains a single, closed volume of triangles. Geometries can
+  also be defined using both CSG and STL representations in this format
+  \cite{Talamo_2018}. The use of separate files to represent volumes
+  independently in this system makes interchanging parts in a geometry
+  straightforward, but ensuring that these parts do not have gaps or overlaps
+  can be a difficult task for users.}
 
 \codecallout{MCNP6}{MCNP6 \cite{Goorley_2016}, developed at Los Alamos National
-  Laboratory, has added the native capability to perform transport on a
-  volumetric mesh of unstructured tetrehedra. Thus a conformal mesh can be
-  generated using a CAD model for transport in this mode. Generating a
-  geometrically constrained volumetric mesh is difficult (and sometimes
+  Laboratory, has added a native capability for transport on a volumetric mesh
+  of unstructured tetrehedra. Thus a conformal mesh can be generated using a CAD
+  model for transport in this mode to achieve good geometry fidelity. Generating
+  a geometrically constrained volumetric mesh is difficult (and sometimes
   impossible) for arbitrary geometries, however. Non-conformal meshes can also
-  be used where tetrahedra overlapping volume boundaries will contain a homogenized
-  mixture of the materials in the mesh element, but the effects of this
-  approximation are difficult to quantify and depend greatly on the importance
-  of the materials involved and mesh element characteristics.}
+  be used where tetrahedra overlapping volume boundaries will contain a
+  homogenized mixture of the materials in the mesh element, but the effects of
+  this approximation are difficult to quantify and depend greatly on the
+  importance of the materials homogenized and mesh element characteristics.}
 
 \codecallout{DAGMC}{ The Direct Accelerated Geometry Monte Carlo (DAGMC)
   software toolkit enables MCRT directly on CAD geometries \cite{Tautges_2004}
   using surface tessellations to represent volume boundaries.  DAGMC was
   developed at the University of Wisconsin - Madison and has been coupled with
-  many Monte Carlo codes (see Table \ref{tab:dagmc_implementations}). DAGMC
-  relies on Cubit\cite{Blacker_1994} (and its commercial counterpart,
-  Trelis\cite{Trelis_2018}) for model importing, cleaning, and
+  many Monte Carlo codes including MCNP (see Table
+  \ref{tab:dagmc_implementations}). DAGMC relies on CUBIT (and its commercial
+  counterpart, Trelis\cite{Trelis_2018}) for model importing, cleaning, and
   tessellation. Surface meshses are stored in the Mesh Oriented dAtaBase (MOAB)
   \cite{Tautges_2009}, developed at Argonne National Laboratory. CUBIT and
-  Trelis are used to ensure volumes to not overlap before discretization, and
-  preproesccing steps ensure models are topologically watertight before
-  transport\cite{Smith_2010}.}
+  Trelis features are used to ensure volumes do not overlap before
+  discretization, and preprocessing steps ensure models are topologically
+  watertight before transport\cite{Smith_2010}.}
 
 Though each of the above methods has its merits, the work of this thesis has
-been implemented in DAGMC. DAGMC has deomonstrated robust transport capability
+been implemented in DAGMC. DAGMC has demonstrated robust transport capability
 on models of varying geometric complexity for a number of physics
-applications. It accomplishes this by discretizing CAD surfaces into sets of
+applications. As mentioned above, it accomplishes this by discretizing CAD surfaces into sets of
 triangles representing surface boundaries. Volumes are then defined by all sets
 of triangles which represent bounding surfaces of a given volume. This surface
 mesh and the geometric relationships between sets of mesh elements, also known

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -276,16 +276,17 @@ the Monte Carlo N-Particle (MCNP) input format developed at Los Alamos National
 Laboratory \cite{LANL_MCNP5_VOLIII}. A few of these tools are described below:
 
 \codecallout{MCAM}{The Monte Carlo Automatic Modeling (MCAM) tool was developed
-  at the Chinese Academy of Sciences. It supports both CAD-to-CSG and CSG-to-CAD
-  conversion, relying on the ACIS . It is capable of fixing gaps and overlaps in
-  models and supports geometry creation. Volumes are decomposed into simplified,
-  convex volumes during CAD-to-CSG translation.}
+  at the Chinese Academy of Sciences \cite{Yu_2013}. It supports both CAD-to-CSG
+  and CSG-to-CAD conversion, relying on the ACIS \cite{ACIS_2018}. It is capable
+  of fixing gaps and overlaps in models and supports geometry creation. Volumes
+  are decomposed into simplified, convex volumes during CAD-to-CSG translation.}
 
 \codecallout{McCad}{McCad was developed at the Karlsruhe Institute of Technology
   in Germany and supports both CAD-to-CSG and CSG-to-CAD model conversion,
-  relying on the Open CASCADE modeling engine to do so. Void spaces in the model
-  are automatically filled in McCad. McCad also decomposes single volumes into
-  multiple volumes with simplified CAG definitions.}
+  relying on the Open CASCADE modeling engine to do so \cite{Grobe_2013,
+    Opencascade_2018}. Void spaces in the model are automatically filled in
+  McCad. McCad also decomposes single volumes into multiple volumes with
+  simplified CAD definitions.}
 
 Though other translation-based methods exist, these tools have the widest
 user base and largest development efforts behind them at the time of this work.
@@ -304,9 +305,9 @@ methods are listed below:
 
 \codecallout{SERPENT}{Serpent \cite{Leppanen_2015} provides CAD-based transport
   using a geometry represented by individual stereolithography (STL) files or
-  ABAQUS mesh. It is expected that the volumes in these files do not occupy the
-  same space and that each file contains a single, closed volume of
-  triangles. Geometries can also be defined using both CSG and STL
+  ABAQUS mesh \cite{ABAQUS_2018}. It is expected that the volumes in these files
+  do not occupy the same space and that each file contains a single, closed
+  volume of triangles. Geometries can also be defined using both CSG and STL
   representations in this format. The use of separate files to represent volumes
   independently in this system makes interchanging parts in a geometry
   straightforward, but ensuring that these parts do not have gaps or overlaps
@@ -388,13 +389,10 @@ the field of ray tracing. In this field, data structures designed to accelerate
 the location of the nearest ray intersection are used to render animations and
 images in real time.
 
-
 % Other tools such as MCAM \cite{Liu_2005} and McCad
 % \cite{Tsigetamirat_2008} allow for interactive visualization and repair of CSG
 % models, but these systems often require simplifications of the true model in
 % translation and limited export formats for various Monte Carlo codes.
-
-
 
 \section{Ray Tracing Acceleration Data Structures}
 

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -18,8 +18,8 @@
 
 \newcommand{\codecallout}[2] {
   \null
-  \textbf{#1}
   \begin{adjustwidth}{1em}{0pt}
+    \textbf{#1:}
     #2
   \end{adjustwidth}
   \null
@@ -273,7 +273,7 @@ makes model manipulation difficult in that a change to the CAD model may result
 more or fewer geometric entities, making tacking of tally mapping difficult from
 CAD to CSG. Several translation approaches have been developed oriented toward
 the Monte Carlo N-Particle (MCNP) input format developed at Los Alamos National
-Laboratory \cite{LANL_MCNP_VOLIII}. A few of these tools are described below:
+Laboratory \cite{LANL_MCNP5_VOLIII}. A few of these tools are described below:
 
 \codecallout{MCAM}{The Monte Carlo Automatic Modeling (MCAM) tool was developed
   at the Chinese Academy of Sciences. It supports both CAD-to-CSG and CSG-to-CAD
@@ -333,7 +333,7 @@ methods are listed below:
   \cite{Tautges_2009}, developed at Argonne National Laboratory. CUBIT and
   Trelis are used to ensure volumes to not overlap before discretization, and
   preproesccing steps ensure models are topologically watertight before
-  transport \cite{Smith_2010}.}
+  transport\cite{Smith_2010}.}
 
 
 Though each of the above methods has its merits, the work of this thesis has

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -303,13 +303,14 @@ complicated surface representations. Several recent implementations of direct
 methods are listed below:
 
 \codecallout{SERPENT}{Serpent \cite{Leppanen_2015} provides CAD-based transport
-  using a geometry represented by individual stereolithography (STL) files. It
-  is expected that the volumes in these files do not occupy the same space and
-  that each file contains a single, closed volume of triangles. Geometries can
-  also be defined using both CSG and STL representations in this format. The use
-  of separate files to represent volumes independently in this system makes
-  interchanging parts in a geometry straightforward, but ensuring that these
-  parts do not have gaps or overlaps can be a difficult task for users.}
+  using a geometry represented by individual stereolithography (STL) files or
+  ABAQUS mesh. It is expected that the volumes in these files do not occupy the
+  same space and that each file contains a single, closed volume of
+  triangles. Geometries can also be defined using both CSG and STL
+  representations in this format. The use of separate files to represent volumes
+  independently in this system makes interchanging parts in a geometry
+  straightforward, but ensuring that these parts do not have gaps or overlaps
+  can be a difficult task for users.}
 
 \codecallout{MCNP6}{MCNP6 \cite{Goorley_2016}, developed at Los Alamos National
   Laboratory, has added the native capability to perform transport on a
@@ -322,19 +323,18 @@ methods are listed below:
   approximation are difficult to quantify and depend greatly on the importance
   of the materials involved and mesh element characteristics.}
 
-\codecallout{DAGMC}{ The Direct Accelerated Geometry Monte Carlo (DAGMC) software toolkit enables
-  MCRT directly on CAD geometries \cite{Tautges_2009} using surface
-  tessellations to represent volume boundaries.  DAGMC was developed at the
-  University of Wisconsin - Madison and has been coupled with many Monte Carlo
-  codes (see Table \ref{tab:dagmc_implementations}). DAGMC relies on
-  Cubit\cite{Blacker_1994} (and its commercial counterpart,
+\codecallout{DAGMC}{ The Direct Accelerated Geometry Monte Carlo (DAGMC)
+  software toolkit enables MCRT directly on CAD geometries \cite{Tautges_2004}
+  using surface tessellations to represent volume boundaries.  DAGMC was
+  developed at the University of Wisconsin - Madison and has been coupled with
+  many Monte Carlo codes (see Table \ref{tab:dagmc_implementations}). DAGMC
+  relies on Cubit\cite{Blacker_1994} (and its commercial counterpart,
   Trelis\cite{Trelis_2018}) for model importing, cleaning, and
   tessellation. Surface meshses are stored in the Mesh Oriented dAtaBase (MOAB)
   \cite{Tautges_2009}, developed at Argonne National Laboratory. CUBIT and
   Trelis are used to ensure volumes to not overlap before discretization, and
   preproesccing steps ensure models are topologically watertight before
   transport\cite{Smith_2010}.}
-
 
 Though each of the above methods has its merits, the work of this thesis has
 been implemented in DAGMC. DAGMC has deomonstrated robust transport capability
@@ -343,8 +343,7 @@ applications. It accomplishes this by discretizing CAD surfaces into sets of
 triangles representing surface boundaries. Volumes are then defined by all sets
 of triangles which represent bounding surfaces of a given volume. This surface
 mesh and the geometric relationships between sets of mesh elements, also known
-as Meshsets, are stored in the Mesh Oriented dAtaBase (MOAB)
-\cite{Tautges_2004}. These relationships, which preserve the geometric topology,
+as Meshsets, are stored in MOAB. These relationships, which preserve the geometric topology,
 are stored in a hierarchical structure within MOAB, relating volumes to their
 surfaces, surfaces to curves, and curves to geometric vertices. For the purposes
 of this work, only the relationship between volumes and surfaces are of

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -16,6 +16,16 @@
   \null
 }
 
+\newcommand{\codecallout}[2] {
+  \null
+  \textbf{#1}
+  \begin{adjustwidth}{1em}{0pt}
+    #2
+  \end{adjustwidth}
+  \null
+}
+
+
 \renewcommand{\thefootnote}{\fnsymbol{footnote}}
 
 
@@ -25,7 +35,7 @@
 
 A Monte Carlo geometry kernel must provide robust support for the geometry
 queries shown in Figures \ref{fig:Point Containment} -
-\ref{fig:Measure}. 
+\ref{fig:Measure}.
 
 \geomQuery{Point Containment}{plc_query}{0.5}{
 Given a set of volumes and particle location, $\mathbf{x}$, determine if the
@@ -97,7 +107,7 @@ modeling using these representations will be discussed in this section.
 An isocontour of this function with the value, $v$, can be described as:
 
 \begin{equation}
-  \Omega(\vec{x}) - v  = 0 
+  \Omega(\vec{x}) - v  = 0
 \end{equation}
 
 For simplicity, the boundary of an implicit surface is conventionally defined as
@@ -209,10 +219,12 @@ Visualization of CSG models is also somewhat limited. Because native formats for
 CSG differ greatly between each Monte Carlo code, each typically provides its
 own geometry visualization tools. These tools are commonly restricted to 2D
 images of the model representing a user-specified slice through the
-geometry. Other tools such as MCAM \cite{Liu_2005} and McCad
-\cite{Tsigetamirat_2008} allow for interactive visualization and repair of CSG
-models, but these systems often require simplifications of the true model in
-translation and limited export formats for various Monte Carlo codes.
+geometry.
+
+% Other tools such as MCAM \cite{Liu_2005} and McCad
+% \cite{Tsigetamirat_2008} allow for interactive visualization and repair of CSG
+% models, but these systems often require simplifications of the true model in
+% translation and limited export formats for various Monte Carlo codes.
 
 \section{CAD Geometry}
 
@@ -243,23 +255,95 @@ complex forms which would be impossible to accurately represent using CSG.
 
 \section{CAD-Based Monte Carlo Radiation Transport}\label{sec:CAD-MCRT}
 
-The Direct Accelerated Geometry Monte Carlo (DAGMC) software toolkit enables
-MCRT directly on CAD geometries \cite{Tautges_2009}. DAGMC was developed at the
-University of Wisconsin - Madison and has been coupled with many Monte Carlo
-codes (see Table \ref{tab:dagmc_implementations}). DAGMC relies on
-Cubit\cite{Blacker_1994} (and its commercial counterpart,
-Trelis\cite{Trelis_2018}) for model importing, cleaning, and tessellation.
+\subsection{Translation-Based Methods}
 
-More specifically, DAGMC provides robust particle tracking for the underlying
-physics kernels of various Monte Carlo codes (see Table
-\ref{tab:dagmc_implementations}. It accomplishes this by discretizing CAD
-surfaces into sets of triangles representing surface boundaries. A tolerance,
-known as the faceting tolerance, is applied during this process to specify the
-maximum allowed distance from a point on the analytic surface to its
-corresponding point on the triangle representation. Volumes are then defined by
-all sets of triangles which represent bounding surfaces of a given volume. This
-surface mesh and the geometric relationships between sets of mesh elements, also
-known as Meshsets, are stored in the Mesh Oriented dAtaBase (MOAB)
+Another approach to CAD-Based MCRT is to leverage the native geometry
+capatilities of Monte Carlo codes by translating CAD geometries into CSG
+representations. In this approach, the fidelity of the geometric representation
+is limited to the geometric primitives available in the supported Monte Carlo
+code. Most codes support only first and second order surfaces, so higher-order
+surfaces of the CAD model must be approximated to accomodate the limited
+representation of the native code. As a result, many of these methods will
+simplify single volumes into smaller, less complex volumes able to be
+represented in CSG. This can be problematic when tally information related to
+CAD entities is desired - surface or volumetric fluxes for a single entity in
+the CAD model must now be mapped over several entities in the CSG
+representation. The lack of one-to-one correlation between CAD and CSG entities
+makes model manipulation difficult in that a change to the CAD model may result
+more or fewer geometric entities, making tacking of tally mapping difficult from
+CAD to CSG. Several translation approaches have been developed oriented toward
+the Monte Carlo N-Particle (MCNP) input format developed at Los Alamos National
+Laboratory \cite{LANL_MCNP_VOLIII}. A few of these tools are described below:
+
+\codecallout{MCAM}{The Monte Carlo Automatic Modeling (MCAM) tool was developed
+  at the Chinese Academy of Sciences. It supports both CAD-to-CSG and CSG-to-CAD
+  conversion, relying on the ACIS . It is capable of fixing gaps and overlaps in
+  models and supports geometry creation. Volumes are decomposed into simplified,
+  convex volumes during CAD-to-CSG translation.}
+
+\codecallout{McCad}{McCad was developed at the Karlsruhe Institute of Technology
+  in Germany and supports both CAD-to-CSG and CSG-to-CAD model conversion,
+  relying on the Open CASCADE modeling engine to do so. Void spaces in the model
+  are automatically filled in McCad. McCad also decomposes single volumes into
+  multiple volumes with simplified CAG definitions.}
+
+Though other translation-based methods exist, these tools have the widest
+user base and largest development efforts behind them at the time of this work.
+
+\subsection{Direct Transport Methods}
+
+In the direct approach to CAD-Based MCRT, geometric queries are performed
+directly on the CAD geometry. Unlike translation-based approaches, physics codes
+must be modified to direct geometric operations to the CAD-Based
+interfaces. Some direct methods perform queries on analytic CAD representations
+while others use discretized forms, but no simplification of the geometry is
+involved. Direct computation on CAD geometries tends to be slower than using
+native geometry because particle tracking is more computationally expensive on
+complicated surface representations. Several recent implementations of direct
+methods are listed below:
+
+\codecallout{SERPENT}{Serpent \cite{Leppanen_2015} provides CAD-based transport
+  using a geometry represented by individual stereolithography (STL) files. It
+  is expected that the volumes in these files do not occupy the same space and
+  that each file contains a single, closed volume of triangles. Geometries can
+  also be defined using both CSG and STL representations in this format. The use
+  of separate files to represent volumes independently in this system makes
+  interchanging parts in a geometry straightforward, but ensuring that these
+  parts do not have gaps or overlaps can be a difficult task for users.}
+
+\codecallout{MCNP6}{MCNP6 \cite{Goorley_2016}, developed at Los Alamos National
+  Laboratory, has added the native capability to perform transport on a
+  volumetric mesh of unstructured tetrehedra. Thus a conformal mesh can be
+  generated using a CAD model for transport in this mode. Generating a
+  geometrically constrained volumetric mesh is difficult (and sometimes
+  impossible) for arbitrary geometries, however. Non-conformal meshes can also
+  be used where tetrahedra overlapping volume boundaries will contain a homogenized
+  mixture of the materials in the mesh element, but the effects of this
+  approximation are difficult to quantify and depend greatly on the importance
+  of the materials involved and mesh element characteristics.}
+
+\codecallout{DAGMC}{ The Direct Accelerated Geometry Monte Carlo (DAGMC) software toolkit enables
+  MCRT directly on CAD geometries \cite{Tautges_2009} using surface
+  tessellations to represent volume boundaries.  DAGMC was developed at the
+  University of Wisconsin - Madison and has been coupled with many Monte Carlo
+  codes (see Table \ref{tab:dagmc_implementations}). DAGMC relies on
+  Cubit\cite{Blacker_1994} (and its commercial counterpart,
+  Trelis\cite{Trelis_2018}) for model importing, cleaning, and
+  tessellation. Surface meshses are stored in the Mesh Oriented dAtaBase (MOAB)
+  \cite{Tautges_2009}, developed at Argonne National Laboratory. CUBIT and
+  Trelis are used to ensure volumes to not overlap before discretization, and
+  preproesccing steps ensure models are topologically watertight before
+  transport \cite{Smith_2010}.}
+
+
+Though each of the above methods has its merits, the work of this thesis has
+been implemented in DAGMC. DAGMC has deomonstrated robust transport capability
+on models of varying geometric complexity for a number of physics
+applications. It accomplishes this by discretizing CAD surfaces into sets of
+triangles representing surface boundaries. Volumes are then defined by all sets
+of triangles which represent bounding surfaces of a given volume. This surface
+mesh and the geometric relationships between sets of mesh elements, also known
+as Meshsets, are stored in the Mesh Oriented dAtaBase (MOAB)
 \cite{Tautges_2004}. These relationships, which preserve the geometric topology,
 are stored in a hierarchical structure within MOAB, relating volumes to their
 surfaces, surfaces to curves, and curves to geometric vertices. For the purposes
@@ -304,6 +388,14 @@ trajectory for a set of geometric primitives is a well-researched problem in
 the field of ray tracing. In this field, data structures designed to accelerate
 the location of the nearest ray intersection are used to render animations and
 images in real time.
+
+
+% Other tools such as MCAM \cite{Liu_2005} and McCad
+% \cite{Tsigetamirat_2008} allow for interactive visualization and repair of CSG
+% models, but these systems often require simplifications of the true model in
+% translation and limited export formats for various Monte Carlo codes.
+
+
 
 \section{Ray Tracing Acceleration Data Structures}
 
@@ -351,13 +443,13 @@ $O(\, log(N_{primitives}))$ search.
 
           if is_leaf(node):
               primitives = get_node_primitives(node)
-    
+
               for primitive in primitives:
                   d = primitive_intersect(primitive, ray)
                   if d < dist: dist = d
 
               continue
-      
+
           if node_intersect(node, ray):
               children = get_node_children(node)
 
@@ -420,7 +512,7 @@ cost, respectively.
 \begin{figure}[H]
 \begin{equation}
 \label{eq:ERH}
- C = \frac{|P_{R}-P_{L}|}{(P_{R} + P_{L})} 
+ C = \frac{|P_{R}-P_{L}|}{(P_{R} + P_{L})}
 \end{equation}
   \begin{align*}
     C - & \,final \, cost \, evaluation \\
@@ -968,7 +1060,7 @@ This representation reduces memory storage of leaf nodes, which can be
 considerable given that the number of leaf nodes in a n-ary tree is
 
 \begin{equation}
- L = n^{h} 
+ L = n^{h}
 \end{equation}
 
 \begin{align*}
@@ -980,7 +1072,7 @@ considerable given that the number of leaf nodes in a n-ary tree is
 meaning a quad tree with a height of ten will contain over one million leaf
 nodes. Avoiding storage of the memory address and leaf node size separately
 reduces memory consumption of the tree and allows the use of fast bit-wise
-operations to differentiate node types when traversing the tree. 
+operations to differentiate node types when traversing the tree.
 
 \paragraph{Memory Prefetching}
 
@@ -1096,7 +1188,7 @@ the traversal stack.
 %%       # inverse direction - ray.invdir
 %%       # inverse direction times the ray origin - ray.org_invdir
 %%       # tNear/tFar - parameter value of intersections along ray direction
-  
+
 %%       # compute tNear for N nodes
 %%       tLowerX = node.lowerX * ray.invdir.x - ray.org.x * ray.invdir.x
 %%       tLowerY = node.lowerY * ray.invdir.y - ray.org.y * ray.invdir.y
@@ -1114,9 +1206,9 @@ the traversal stack.
 %%       tFarX =  max(tLowerX, tUpperX)
 %%       tFarY =  max(tLowerY, tUpperY)
 %%       tFarZ =  max(tLowerZ, tUpperZ)
-      
+
 %%       # compute maximum tnear for all boxes
-%%       tNear = max(tNearX, tNearY, tNearZ, ray.tNear) 
+%%       tNear = max(tNearX, tNearY, tNearZ, ray.tNear)
 %%       tFar =  min(tFarX,  tFarY,  tFarZ,  ray.tFar )
 
 %%       # compute a mask indicating which boxes are hit
@@ -1138,7 +1230,7 @@ the traversal stack.
       # inverse direction - ray.invdir
       # inverse direction times the ray origin - ray.org_invdir
       # tNear/tFar - parameter value of intersections along ray direction
-  
+
       # compute tNear for N nodes
       tNearX = vecN(&node + ray.nearX) * ray.invdir.x - ray.org.x * ray.invdir.x
       tNearY = vecN(&node + ray.nearY) * ray.invdir.y - ray.org.y * ray.invdir.y
@@ -1150,7 +1242,7 @@ the traversal stack.
       tFarZ = vecN(&node + ray.farZ) * ray.invdir.z - ray.org.z * ray.invdir.z
 
       # compute maximum tnear for all boxes
-      tNear = max(tNearX, tNearY, tNearZ, ray.tNear) 
+      tNear = max(tNearX, tNearY, tNearZ, ray.tNear)
       tFar =  min(tFarX,  tFarY,  tFarZ,  ray.tFar )
 
       # compute a mask indicating which boxes are hit
@@ -1210,10 +1302,10 @@ visualization and simulation can be readily recovered from implicit surfaces.
 %% where an isocontour of value, $v$, of the implicit surface can be
 %% described as
 %% \begin{equation} \label{eq:implicit_surf_isocontour}
-%%   \Omega(\vec{x}) - v  = 0 
+%%   \Omega(\vec{x}) - v  = 0
 %% \end{equation}
 %% for all points $\vec{x}$ satisfying that equation. For simplicity, the surface
-%% isocontour value is typically defined as $0$. 
+%% isocontour value is typically defined as $0$.
 
 %% By recognizing that the magnitude of $\Omega(\vec{x})$ is in fact a
 %% minimum interface distance function, one can construct a signed

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -275,12 +275,13 @@ developed oriented toward the Monte Carlo N-Particle (MCNP) input format
 developed at Los Alamos National Laboratory \cite{LANL_MCNP5_VOLIII}. A few of
 these tools are described below:
 
-\codecallout{MCAM}{The Monte Carlo Automatic Modeling (MCAM) tool was developed
-  at the Chinese Academy of Sciences \cite{Yu_2013}. It supports both CAD-to-CSG
-  and CSG-to-CAD conversion, relying on the ACIS \cite{ACIS_2018} geometry
-  engine. It is capable of fixing gaps and overlaps in models and supports
-  geometry creation. Volumes are decomposed into simplified, convex volumes
-  during CAD-to-CSG translation.}
+\codecallout{MCAM}{CAD support for the Super Monte Carlo (SuperMC) code
+  developed at the Chinese Academy of Sciences is provided by the Monte Carlo
+  Automatic Modeling (MCAM) tool \cite{Wu_2015, Yu_2013}. It supports both
+  CAD-to-CSG and CSG-to-CAD conversion, relying on the ACIS \cite{ACIS_2018}
+  geometry engine. It is capable of fixing gaps and overlaps in models and
+  supports geometry creation. Volumes are decomposed into simplified, convex
+  volumes during CAD-to-CSG translation.}
 
 \codecallout{McCad}{McCad was developed at the Karlsruhe Institute of Technology
   in Germany and supports both CAD-to-CSG and CSG-to-CAD model conversion,

--- a/document/chapters/02-background.tex
+++ b/document/chapters/02-background.tex
@@ -275,8 +275,8 @@ developed oriented toward the Monte Carlo N-Particle (MCNP) input format
 developed at Los Alamos National Laboratory \cite{LANL_MCNP5_VOLIII}. A few of
 these tools are described below:
 
-\codecallout{MCAM}{CAD support for the Super Monte Carlo (SuperMC) code
-  developed at the Chinese Academy of Sciences is provided by the Monte Carlo
+\codecallout{MCAM}{CAD support for the Super Monte Carlo (SuperMC) code,
+  developed at the Chinese Academy of Sciences, is provided by the Monte Carlo
   Automatic Modeling (MCAM) tool \cite{Wu_2015, Yu_2013}. It supports both
   CAD-to-CSG and CSG-to-CAD conversion, relying on the ACIS \cite{ACIS_2018}
   geometry engine. It is capable of fixing gaps and overlaps in models and

--- a/document/includes/preamble.tex
+++ b/document/includes/preamble.tex
@@ -23,6 +23,7 @@
 \usepackage[export]{adjustbox}
 \usepackage{makecell}
 \usepackage[dvipsnames]{xcolor}
+\usepackage{cite}
 
 %% You should use natbib
 \IfFileExists{natbib.sty}{%

--- a/document/refs.bib
+++ b/document/refs.bib
@@ -775,3 +775,16 @@ title = { 3-D ACIS Modeling },
 howpublished = { \url{https://www.spatial.com/products/3d-acis-modeling}},
 year = 2018
 }
+@article{Wu_2015,
+title = "CAD-based Monte Carlo program for integrated simulation of nuclear system SuperMC",
+journal = "Annals of Nuclear Energy",
+volume = "82",
+pages = "161 - 168",
+year = "2015",
+note = "Joint International Conference on Supercomputing in Nuclear Applications and Monte Carlo 2013, SNA + MC 2013. Pluri- and Trans-disciplinarity, Towards New Modeling and Numerical Simulation Paradigms",
+issn = "0306-4549",
+doi = "https://doi.org/10.1016/j.anucene.2014.08.058",
+url = "http://www.sciencedirect.com/science/article/pii/S0306454914004587",
+author = "Yican Wu and Jing Song and Huaqing Zheng and Guangyao Sun and Lijuan Hao and Pengcheng Long and Liqin Hu",
+keywords = "Monte Carlo simulation, CAD-based, Multi-physics, Nuclear system, SuperMC",
+}

--- a/document/refs.bib
+++ b/document/refs.bib
@@ -756,3 +756,22 @@ title = {ABAQUS (FINITE ELEMENT ANALYSIS \& MULTIPHYSICS SIMULATION)},
 howpublished = { \url{http://www.feasol.com/solutions/engineering-simulation/abaqus/}},
 year = 2018
 }
+@article{Talamo_2018,
+title = "SERPENT validation and optimization with mesh adaptive search on stereolithography geometry models",
+journal = "Annals of Nuclear Energy",
+volume = "115",
+pages = "619 - 632",
+year = "2018",
+issn = "0306-4549",
+doi = "https://doi.org/10.1016/j.anucene.2018.01.012",
+url = "http://www.sciencedirect.com/science/article/pii/S0306454918300112",
+author = "Alberto Talamo and Yousry Gohar and J. Leppänen",
+keywords = "Unstructured mesh, Tetrahedron, Stereolithography, ABAQUS, CUBIT"
+}
+
+@misc{ACIS_2018,
+author = {ACIS},
+title = { 3-D ACIS Modeling },
+howpublished = { \url{https://www.spatial.com/products/3d-acis-modeling}},
+year = 2018
+}

--- a/document/refs.bib
+++ b/document/refs.bib
@@ -715,3 +715,44 @@ abstract     = "Computer Graphics since its existence has been striving to visua
 	year = {2010}
 }
 
+@article{Grobe_2013,
+title = "Status of the McCad geometry conversion tool and related visualization capabilities for 3D fusion neutronics calculations",
+journal = "Fusion Engineering and Design",
+volume = "88",
+number = "9",
+pages = "2210 - 2214",
+year = "2013",
+note = "Proceedings of the 27th Symposium On Fusion Technology (SOFT-27); Liège, Belgium, September 24-28, 2012",
+issn = "0920-3796",
+doi = "https://doi.org/10.1016/j.fusengdes.2013.02.146",
+url = "http://www.sciencedirect.com/science/article/pii/S0920379613002615",
+author = "D. Große and U. Fischer and K. Kondo and D. Leichtle and P. Pereslavtsev and A. Serikov",
+keywords = "CAD, Monte Carlo, Neutronics, ITER, IFMIF"
+}
+
+@article{Yu_2013,
+issn = {0003-018X},
+journal = {Transactions of the American Nuclear Society},
+pages = {724--725},
+volume = {109},
+year = {2013},
+title = {MCAM 5.2: Advanced Interface Program for Multiple Nuclear Analysis Codes},
+language = {eng},
+author = {Yu, Shengpeng and Wu, Yican},
+keywords = {Three Dimensional ; Radiation Transport ; Nuclear Reactors ; Mathematical Models ; Computer Simulation ; Monte Carlo Methods ; Nuclear Reactor Components ; Nuclear Engineering},
+url = {http://search.proquest.com/docview/1567086187/},
+}
+
+@misc{Opencascade_2018,
+author = {Open CASCADE},
+title = "Open CASCADE technology, 3D Modeling \& Numerical Simulation",
+howpublished = { \url{https://www.opencascade.com/}},
+year = 2018
+}
+
+@misc{ABAQUS_2018,
+author = {ABAQUS},
+title = {ABAQUS (FINITE ELEMENT ANALYSIS \& MULTIPHYSICS SIMULATION)},
+howpublished = { \url{http://www.feasol.com/solutions/engineering-simulation/abaqus/}},
+year = 2018
+}

--- a/document/refs.bib
+++ b/document/refs.bib
@@ -706,3 +706,12 @@ abstract     = "Computer Graphics since its existence has been striving to visua
 	title = {Computer Architecture: A Quantitative Approach},
 	year = 2012
 }
+@article{Smith_2010,
+	address = {Chattanooga, TN, United States},
+	title = {Sealing {Faceted} {Surfaces} to {Achieve} {Watertight} {CAD} {Models}},
+	author = {Smith, B.M. and Tautges, T.J. and Wilson, P.P.H.},
+	booktitle = {19th International Meshing Roundtable},
+	month = oct,
+	year = {2010}
+}
+


### PR DESCRIPTION
These changes are intended to resolve #5.

I've added a section on different methods/capabilities inspired by the one in B. Smiths 2011 thesis, detailing a few of the direct and translation-based approaches in use today. That may be an insufficient set of tools due to my limited knowledge of tools in the field and I try to recognize that in the text. 

I tried to find results for performance information on MCAM and McCad, but in their papers I only saw a commentary on translation times without mention of simulation times. For SERPENT I found a very recent paper with performance information [here](https://www.sciencedirect.com/science/article/pii/S0306454918300112) but after puzzling out the data points they were reporting I was hesitant to add any quantitative info. In that paper, they seemed to only claim to be as good as MCNP after moving a considerable amount of their geometry from STL to CSG or running 1/40th as many neutrons in an eigenvalue simulation... that could be an incorrect analysis though - it's late.
